### PR TITLE
Use `File.Exists` instead of `Directory.GetFiles` in `WhichUtil.Which`

### DIFF
--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -95,13 +95,11 @@ namespace GitHub.Runner.Sdk
 #else
                     try
                     {
-                        foreach (var file in Directory.EnumerateFiles(pathSegment, command))
+                        string file = Path.Join(pathSegment, command);
+                        if (File.Exists(file) && IsPathValid(file, trace))
                         {
-                            if (IsPathValid(file, trace))
-                            {
-                                trace?.Info($"Location: '{file}'");
-                                return file;
-                            }
+                            trace?.Info($"Location: '{file}'");
+                            return file;
                         }
                     }
                     catch (UnauthorizedAccessException ex)


### PR DESCRIPTION
On FreeBSD's Linux compatibility layer, `Directory.GetFiles` does not work properly and always returns an empty array, so the equivalent functionality is achieved using `File.Exists`.